### PR TITLE
 adding const for TFnc parameter in CtcPicard constructor

### DIFF
--- a/src/core/contractors/dyn/codac_CtcPicard.cpp
+++ b/src/core/contractors/dyn/codac_CtcPicard.cpp
@@ -25,7 +25,7 @@ namespace codac
     assert(delta > 0.);
   }
 
-  CtcPicard::CtcPicard(TFnc& f, float delta)
+  CtcPicard::CtcPicard(const TFnc& f, float delta)
     : DynCtc(true), m_f(f), m_delta(delta)
   {
     assert(f.nb_var() == f.image_dim());

--- a/src/core/contractors/dyn/codac_CtcPicard.h
+++ b/src/core/contractors/dyn/codac_CtcPicard.h
@@ -27,7 +27,7 @@ namespace codac
     public:
 
       CtcPicard(Function& f, float delta = 1.1);
-      CtcPicard(TFnc& f, float delta = 1.1);
+      CtcPicard(const TFnc& f, float delta = 1.1);
       ~CtcPicard();
 
       void contract(std::vector<Domain*>& v_domains);


### PR DESCRIPTION
adding const for TFnc parameter in CtcPicard constructor for calling the constructor from the solver with a TFnc parameter already const